### PR TITLE
Merge root-level tags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,22 @@ class Merger extends EventEmitter {
     }
     return ret;
   }
+  _mergedTags(swaggers) {
+    let ret = [];
+    for (let i = 0; i < swaggers.length; i++) {
+      let swagger = swaggers[i];
+      if (swagger.tags) {
+        let ref = swagger.tags;
+        for (let j = 0; j < ref.length; j++) {
+          let tag = ref[j];
+          if (tag && ret.indexOf(tag) < 0) {
+            ret.push(tag);
+          }
+        }
+      }
+    }
+    return ret;
+  }
   _mergedSchemes(swaggers) {
     let ret = [];
     for (let i = 0; i < swaggers.length; i++) {
@@ -162,7 +178,8 @@ class Merger extends EventEmitter {
       basePath: basePath,
       schemes: schemes || this._mergedSchemes(swaggers),
       consumes: this._mergedConsume(swaggers),
-      produces: this._mergedProduces(swaggers)
+      produces: this._mergedProduces(swaggers),
+      tags: this._mergedTags(swaggers)
     };
     securityDefinitions = this._mergeSecurityDefinitions(swaggers);
     if (securityDefinitions) {

--- a/test/swagger1.json
+++ b/test/swagger1.json
@@ -16,6 +16,12 @@
     "produces": [
         "application/json"
     ],
+    "tags": [
+        {
+            "name": "Users",
+            "description": "Users go here"
+        }
+    ],
     "paths": {
         "/users": {
             "get": {

--- a/test/swagger2.json
+++ b/test/swagger2.json
@@ -23,6 +23,12 @@
   "produces": [
     "application/json"
   ],
+  "tags": [
+    {
+      "name": "Pets",
+      "description": "Pets go here"
+    }
+  ],
   "paths": {
     "/pets": {
       "get": {

--- a/test/swagger3.json
+++ b/test/swagger3.json
@@ -17,6 +17,12 @@
     "produces": [
         "application/json"
     ],
+    "tags": [
+        {
+            "name": "Security",
+            "description": "Security goes here"
+        }
+    ],
     "securityDefinitions": {
         "securitylogin": {
             "type": "basic",

--- a/test/testSpec.coffee
+++ b/test/testSpec.coffee
@@ -141,3 +141,16 @@ describe "Run swagger merge", ()->
 
         merged = swaggermerge.merge([swaggerOne, swaggerTwo, swaggerThree], info, '/api', 'test.com')
         expect(swagger.validate(merged)).toBe(true)
+    it "merge swagger with tags", (done)->
+        info = 
+            version: "0.0.1",
+            title: "merged swaggers",
+            description: "all mighty services merged together\n"
+        swaggerOne.responses = JSON.parse JSON.stringify swaggerTwo.responses
+
+        swaggermerge.on 'warn', (msg)=>
+            done()
+
+        merged = swaggermerge.merge([swaggerOne, swaggerTwo, swaggerThree], info, '/api', 'test.com')
+        expect(swagger.validate(merged)).toBe(true)
+        expect(merged.tags).not.toBeNull()


### PR DESCRIPTION
Top-level tags array was being dropped during merge. This merges tags from all swaggers.