### PR TITLE
Merge swagger with extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,21 @@ class Merger extends EventEmitter {
     }
     return ret;
   }
+  _mergedExtensions(swaggers) {
+    let ret = {};
+    for (let i = 0; i < swaggers.length; i++) {
+      let swagger = swaggers[i];
+      let extensionNames = Object.keys(swagger).filter(key => key.startsWith('x-'))
+      for (let j = 0; j < extensionNames.length; j++) {
+        let extensionName = extensionNames[j];
+        let extension = swagger[extensionName];
+        if (extension && !ret[extensionName]) {
+          ret[extensionName] = extension;
+        }
+      }
+    }
+    return ret;
+  }
   _mergedParameters(swaggers) {
     return this._mergedFieldObject(swaggers, 'parameters');
   }
@@ -161,7 +176,7 @@ class Merger extends EventEmitter {
     return ret;
   }
   merge(swaggers, info, basePath, host, schemes) {
-    let definitions, parameters, paths, responses, ret, securityDefinitions;
+    let definitions, parameters, paths, responses, ret, securityDefinitions, extensions;
     if (typeof info !== 'object') {
       throw 'no info object as input or different format';
     }
@@ -200,6 +215,12 @@ class Merger extends EventEmitter {
     responses = this._mergedResponses(swaggers);
     if (responses) {
       ret.responses = responses;
+    }
+    extensions = this._mergedExtensions(swaggers);
+    if (extensions) {
+      Object.keys(extensions).forEach(key => {
+        ret[key] = extensions[key];
+      })
     }
     return ret;
   }

--- a/test/swagger1.json
+++ b/test/swagger1.json
@@ -5,6 +5,8 @@
         "title": "User service",
         "description": "User Management and Authentication service"
     },
+    "x-extension-1": "correct-1",
+    "x-extension-1b": "correct-1b",
     "host": "test.com",
     "basePath": "/user",
     "schemes": [

--- a/test/swagger2.json
+++ b/test/swagger2.json
@@ -12,6 +12,8 @@
       "name": "MIT"
     }
   },
+  "x-extension-2": "correct-2",
+  "x-extension-1b": "wrong-should-not-be-here-1b",
   "host": "test.com",
   "basePath": "/petstore",
   "schemes": [

--- a/test/swagger3.json
+++ b/test/swagger3.json
@@ -5,6 +5,8 @@
         "title": "Zettabox HoS Admin",
         "description": "administration API for zettabox service\n"
     },
+    "x-extension-3": "correct-3",
+    "x-extension-1b": "wrong-should-not-be-here-1b",
     "host": "test.com",
     "basePath": "/zbadmin",
     "schemes": [

--- a/test/testSpec.coffee
+++ b/test/testSpec.coffee
@@ -154,3 +154,21 @@ describe "Run swagger merge", ()->
         merged = swaggermerge.merge([swaggerOne, swaggerTwo, swaggerThree], info, '/api', 'test.com')
         expect(swagger.validate(merged)).toBe(true)
         expect(merged.tags).not.toBeNull()
+
+    it "merge swagger with extenstions", (done)->
+        info = 
+            version: "0.0.1",
+            title: "merged swaggers",
+            description: "all mighty services merged together\n"
+        swaggerOne.responses = JSON.parse JSON.stringify swaggerTwo.responses
+
+        swaggermerge.on 'warn', (msg)=>
+            done()
+
+        merged = swaggermerge.merge([swaggerOne, swaggerTwo, swaggerThree], info, '/api', 'test.com')
+        expect(swagger.validate(merged)).toBe(true)
+        expect(merged['x-extension-1']).toBe('correct-1')
+        expect(merged['x-extension-1b']).toBe('correct-1b')
+        expect(merged['x-extension-2']).toBe('correct-2')
+        expect(merged['x-extension-3']).toBe('correct-3')
+


### PR DESCRIPTION
This PR makes possible to merge files having global-space specification extensions as described by [the swagger docs](https://swagger.io/specification/#specificationExtensions).